### PR TITLE
Update requirements_versions.txt

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,3 +1,4 @@
+httpx==0.24.1
 GitPython==3.1.32
 Pillow==9.5.0
 accelerate==0.21.0


### PR DESCRIPTION
fix https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/13236

 .\webui-user.bat creates venv with wrong version httpx-0.25.1 which doesn't work because there is no parameter socket_options , enforce httpx-0.24.1